### PR TITLE
add capistrano invoke task

### DIFF
--- a/app/assets/javascripts/helpers.coffee
+++ b/app/assets/javascripts/helpers.coffee
@@ -117,12 +117,12 @@ class RestaurantStorage
    * Get restaurants from server API endpoint.
    * @type {String}
   ###
-  RESTAURANTS_URL = '/restaurants'
+  RESTAURANTS_URL = location.pathname.substring(1) + '/restaurants'
   ###*
    * Restaurants data object API endpoint.
    * @type {String}
   ###
-  VERSION_URL = '/version'
+  VERSION_URL = location.pathname.substring(1) + '/version'
 
   ###*
    * Polyfill for jQuery's getJSON (not implementing all jQuery functionallity).

--- a/lib/capistrano/tasks/invoke.cap
+++ b/lib/capistrano/tasks/invoke.cap
@@ -1,0 +1,10 @@
+desc 'Invoke a rake command on the remote server, use as cap [stage] invoke[task]'
+task :invoke, [:command] => 'deploy:set_rails_env' do |task, args|
+  on primary(:app) do
+    within current_path do
+      with :rails_env => fetch(:rails_env) do
+        rake args[:command]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use to execute a `rake` task at remote deploy.
Usage: `cap [stage (e.g. production)] invoke[task_name]`.